### PR TITLE
Eliminate Moment.js

### DIFF
--- a/Formats.md
+++ b/Formats.md
@@ -1,0 +1,49 @@
+The code for formatting dates and times are borrowed from https://blog.stevenlevithan.com/archives/javascript-date-format
+
+| Mask | Description |
+| --- | --- |
+| d | Day of the month as digits; no leading zero for single-digit days. |
+| dd  | Day of the month as digits; leading zero for single-digit days. |
+| ddd | Day of the week as a three-letter abbreviation. |
+| dddd | Day of the week as its full name. |
+| m | Month as digits; no leading zero for single-digit months. |
+| mm | Month as digits; leading zero for single-digit months. |
+| mmm | Month as a three-letter abbreviation. |
+| mmmm | Month as its full name. |
+| yy | Year as last two digits; leading zero for years less than 10. |
+| yyyy | Year represented by four digits. |
+| h | Hours; no leading zero for single-digit hours (12-hour clock). |
+ |hh | Hours; leading zero for single-digit hours (12-hour clock). |
+| H | Hours; no leading zero for single-digit hours (24-hour clock). |
+| HH | Hours; leading zero for single-digit hours (24-hour clock). |
+| M | Minutes; no leading zero for single-digit minutes. Uppercase M unlike CF timeFormat's m to avoid conflict with months. |
+| MM | Minutes; leading zero for single-digit minutes. Uppercase MM unlike CF timeFormat's mm to avoid conflict with months. |
+| s | Seconds; no leading zero for single-digit seconds. |
+| ss | Seconds; leading zero for single-digit seconds. |
+| l or L | Milliseconds. l gives 3 digits. L gives 2 digits. |
+| t | Lowercase, single-character time marker string: a or p. No equivalent in CF. |
+| tt | Lowercase, two-character time marker string: am or pm. No equivalent in CF. |
+| T | Uppercase, single-character time marker string: A or P. Uppercase T unlike CF's t to allow for user-specified casing. |
+| TT | Uppercase, two-character time marker string: AM or PM. Uppercase TT unlike CF's tt to allow for user-specified casing. |
+| Z | US timezone abbreviation, e.g. EST or MDT. With non-US timezones or in the Opera browser, the GMT/UTC offset is returned, e.g. GMT-0500. No equivalent in CF. |
+| o | GMT/UTC timezone offset, e.g. -0500 or +0230. No equivalent in CF. |
+| S | The date's ordinal suffix (st, nd, rd, or th). Works well with d. No equivalent in CF. |
+| '…' or "…" | Literal character sequence. Surrounding quotes are removed. No equivalent in CF. |
+| UTC: | Must be the first four characters of the mask. Converts the date from local time to UTC/GMT/Zulu time before applying the mask. The "UTC:" prefix is removed. No equivalent in CF. |
+
+There are some predefined masks
+
+| Name | Mask | Example |
+| --- | --- | --- |
+| default | ddd mmm dd yyyy HH:MM:ss | Sat Jun 09 2007 17:46:21 |
+| shortDate | m/d/yy | 6/9/07 |
+| mediumDate | mmm d, yyyy | Jun 9, 2007 |
+| longDate | mmmm d, yyyy | June 9, 2007 |
+| fullDate | dddd, mmmm d, yyyy | Saturday, June 9, 2007
+| shortTime | h:MM TT | 5:46 PM |
+| mediumTime | h:MM:ss TT | 5:46:21 PM |
+| longTime | h:MM:ss TT Z | 5:46:21 PM EST |
+| isoDate | yyyy-mm-dd | 2007-06-09 |
+| isoTime | HH:MM:ss | 17:46:21 |
+| isoDateTime | yyyy-mm-dd'T'HH:MM:ss | 2007-06-09T17:46:21 |
+| isoUtcDateTime | UTC:yyyy-mm-dd'T'HH:MM:ss'Z' | 2007-06-09T22:46:21Z |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 # Lovelace Analog Clock
 An analog clock card for Home Assistant Lovelace. Colors are fully customizable, weekday names and date formats are localizable.
 
+```diff
+- Breaking changes
+Some of the masks for 'dateformat' and 'timeformat' have changed text. Please see Formats for the new masks.
+```
+
 ## Installation
 
 Install using HACS, search for 'Analog Clock'.
@@ -13,18 +18,9 @@ type: "custom:analog-clock"
 ```
 You might have to add a character and remove it again, before the Save button becomes active.
 
-In addition to the js file is moment.js needed, but only if you plan to use dateformat or timeformat. To install moment.js add these lines in the section 'resources' in ui-lovelace.yaml:
-```
-  - url: https://unpkg.com/moment@2.30.1/min/moment-with-locales.js
-    type: js
-```
-
-If you use the dateformat or timeformat and date or digital time are not shown, that probably means moment.js is not properly loaded. Refresh the cache in your browser.
-
 ## Configuration
 
-For a list of available options for dateformat and timeformat, see this:
-https://momentjs.com/docs/#/displaying/format/
+For a list of available options for dateformat and timeformat, see Formats.
 
 ![Analog clock2](https://github.com/tomasrudh/analogclock/blob/main/Images/AnalogClock2.png?raw=true)
 
@@ -54,8 +50,8 @@ https://momentjs.com/docs/#/displaying/format/
 | style_hourhand | Integer | 1 | Style for the hour hand |
 | style_minutehand | Integer | 1 | Style for the minute hand |
 | style_secondhand | Integer | 3 | Style for the second hand |
-| dateformat | String | HA setting | Format for the date (Require moment.js) |
-| timeformat | String | HA setting | Format for the time (Require moment.js) |
+| dateformat | String | HA setting | Format for the date |
+| timeformat | String | HA setting | Format for the time |
 
 Themes are settings that are applied during a time interval. Any setting except timezone and diameter can be set in themes. There can be multiple 'time' sections.
 
@@ -82,11 +78,11 @@ All colors can be entered in one of four different ways:
   hide_SecondHand: true
   locale: sv-SE
   diameter: 200
-  color_HourHand: "#326ba8"
-  color_MinuteHand: "#3273a8"
-  color_DigitalTime: "#CCCCCC"
-  color_FaceDigits: "#a83832"
-  color_Ticks: "Silver"
+  color_hourhand: "#326ba8"
+  color_minutehand: "#3273a8"
+  color_digitaltime: "#CCCCCC"
+  color_facedigits: "#a83832"
+  color_ticks: "Silver"
   themes:
   - time: 23:00-08:00
     color_background: maroon
@@ -94,11 +90,11 @@ All colors can be entered in one of four different ways:
 ![Analog clock4](https://github.com/tomasrudh/analogclock/blob/main/Images/AnalogClock4.png?raw=true)
 ```
 - type: "custom:analog-clock"
-  hide_SecondHand: true
-  color_HourHand: "#326ba8"
-  color_MinuteHand: "#3273a8"
-  color_DigitalTime: "#CCCCCC"
-  color_FaceDigits: "#a83832"
+  hide_secondhand: true
+  color_hourhand: "#326ba8"
+  color_minutehand: "#3273a8"
+  color_digitaltime: "#CCCCCC"
+  color_facedigits: "#a83832"
   hide_minorticks: true
   timezone: America/Fortaleza
   timezonedisplayname: "UTC-3"
@@ -140,11 +136,11 @@ elements:
     hide_facedigits: true
     dateformat: "YYYY-MM-DD"
     color_background: rgba(0,0,0,0)
-    color_HourHand: "#326ba8"
-    color_MinuteHand: "#3293a8"
+    color_hourhand: "#326ba8"
+    color_minutehand: "#3293a8"
     color_secondhand: red
-    color_DigitalTime: "#CCCCCC"
-    color_FaceDigits: "#a83832"
+    color_digitaltime: "#CCCCCC"
+    color_facedigits: "#a83832"
     card_mod:
       style: |
         ha-card {

--- a/dist/analogclock.js
+++ b/dist/analogclock.js
@@ -1,8 +1,12 @@
 class AnalogClock extends HTMLElement {
   set hass(hass) {
-    if (!this.content) {
-      console.info(`%c ANALOG-CLOCK v2.0 `, 'color: white; font-weight: bold; background: black');
 
+    const formatStackTrace = (stack) => {
+      return stack.split("\n").map(line => line.trim());
+    };
+
+    if (!this.content) {
+      console.info(`%c ANALOG-CLOCK v3.0 `, 'color: white; font-weight: bold; background: black');
       var config = this.config;
       const card = document.createElement('ha-card');
       this.content = document.createElement('div');
@@ -21,7 +25,6 @@ class AnalogClock extends HTMLElement {
       //ctx.textBaseline = 'middle';
       var radius = (canvas.width < canvas.height) ? canvas.width / 2.1 : canvas.height / 2.1;
       //ctx.translate(canvas.width / 2, canvas.height / 2);
-
       var canvasHourEl = document.createElement('canvas');
       canvasHourEl.width = canvas.width
       canvasHourEl.height = canvas.height
@@ -44,6 +47,131 @@ class AnalogClock extends HTMLElement {
 
       var layerCachedForMinute = -1;
       getConfig();
+
+      /*
+       * Date Format 1.2.3
+       * (c) 2007-2009 Steven Levithan <stevenlevithan.com>
+       * MIT license
+       *
+       * Includes enhancements by Scott Trenda <scott.trenda.net>
+       * and Kris Kowal <cixar.com/~kris.kowal/>
+       *
+       * Accepts a date, a mask, or a date and a mask.
+       * Returns a formatted version of the given date.
+       * The date defaults to the current date/time.
+       * The mask defaults to dateFormat.masks.default.
+       */
+      var dateFormat = function () {
+        var token = /d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZ]|"[^"]*"|'[^']*'/g,
+          timezone = /\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,
+          timezoneClip = /[^-+\dA-Z]/g,
+          pad = function (val, len) {
+            val = String(val);
+            len = len || 2;
+            while (val.length < len) val = "0" + val;
+            return val;
+          };
+
+        // Regexes and supporting functions are cached through closure
+        return function (date, mask, utc) {
+          var dF = dateFormat;
+
+          // You can't provide utc if you skip other args (use the "UTC:" mask prefix)
+          if (arguments.length == 1 && Object.prototype.toString.call(date) == "[object String]" && !/\d/.test(date)) {
+            mask = date;
+            date = undefined;
+          }
+
+          // Passing date through Date applies Date.parse, if necessary
+          date = date ? new Date(date) : new Date;
+          if (isNaN(date)) throw SyntaxError("invalid date");
+
+          mask = String(dF.masks[mask] || mask || dF.masks["default"]);
+
+          // Allow setting the utc argument via the mask
+          if (mask.slice(0, 4) == "UTC:") {
+            mask = mask.slice(4);
+            utc = true;
+          }
+
+          var _ = utc ? "getUTC" : "get",
+            d = date[_ + "Date"](),
+            D = date[_ + "Day"](),
+            m = date[_ + "Month"](),
+            y = date[_ + "FullYear"](),
+            H = date[_ + "Hours"](),
+            M = date[_ + "Minutes"](),
+            s = date[_ + "Seconds"](),
+            L = date[_ + "Milliseconds"](),
+            o = utc ? 0 : date.getTimezoneOffset(),
+            flags = {
+              d: d,
+              dd: pad(d),
+              ddd: intlDay('short'),
+              dddd: intlDay('long'),
+              m: m + 1,
+              mm: pad(m + 1),
+              mmm: intlMonth('short'),
+              mmmm: intlMonth('long'),
+              yy: String(y).slice(2),
+              yyyy: y,
+              h: H % 12 || 12,
+              hh: pad(H % 12 || 12),
+              H: H,
+              HH: pad(H),
+              M: M,
+              MM: pad(M),
+              s: s,
+              ss: pad(s),
+              l: pad(L, 3),
+              L: pad(L > 99 ? Math.round(L / 10) : L),
+              t: H < 12 ? "a" : "p",
+              tt: H < 12 ? "am" : "pm",
+              T: H < 12 ? "A" : "P",
+              TT: H < 12 ? "AM" : "PM",
+              Z: utc ? "UTC" : (String(date).match(timezone) || [""]).pop().replace(timezoneClip, ""),
+              o: (o > 0 ? "-" : "+") + pad(Math.floor(Math.abs(o) / 60) * 100 + Math.abs(o) % 60, 4),
+              S: ["th", "st", "nd", "rd"][d % 10 > 3 ? 0 : (d % 100 - d % 10 != 10) * d % 10]
+            };
+
+          return mask.replace(token, function ($0) {
+            return $0 in flags ? flags[$0] : $0.slice(1, $0.length - 1);
+          });
+        };
+      }();
+
+      // Some common format strings
+      dateFormat.masks = {
+        "default": "ddd mmm dd yyyy HH:MM:ss",
+        shortDate: "m/d/yy",
+        mediumDate: "mmm d, yyyy",
+        longDate: "mmmm d, yyyy",
+        fullDate: "dddd, mmmm d, yyyy",
+        shortTime: "h:MM TT",
+        mediumTime: "h:MM:ss TT",
+        longTime: "h:MM:ss TT Z",
+        isoDate: "yyyy-mm-dd",
+        isoTime: "HH:MM:ss",
+        isoDateTime: "yyyy-mm-dd'T'HH:MM:ss",
+        isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"
+      };
+
+      // For convenience...
+      Date.prototype.format = function (mask, utc) {
+        return dateFormat(this, mask, utc);
+      };
+
+      function intlMonth(length) {
+        var now = new Date();
+        var options = { month: length };
+        return now.toLocaleDateString(locale, options);
+      }
+
+      function intlDay(length) {
+        var now = new Date();
+        var options = { weekday: length };
+        return now.toLocaleDateString(locale, options);
+      }
 
       drawClock();
       if (this.hide_SecondHand) {
@@ -280,8 +408,7 @@ class AnalogClock extends HTMLElement {
         var timeString = now.toLocaleTimeString(locale, options);
         if (timeFormat) {
           try {
-            var nowmoment = moment(now);
-            timeString = nowmoment.format(timeFormat);
+            timeString = dateFormat(now, timeFormat)
           }
           catch (err) {
             showerror(err, ctx, radius)
@@ -300,13 +427,12 @@ class AnalogClock extends HTMLElement {
       function drawDate(ctx, now, locale, radius, color) {
         ctx.font = Math.round(radius / 7) + 'px Sans-Serif';
         ctx.fillStyle = color
-        if (dateFormat) {
+        if (dateMask) {
           //"20111010T1020"
           var datestring = now.toLocaleString('sv-SE');
           //var datestring = '2021-01-10 10:08';
           try {
-            var nowmoment = moment(datestring);
-            ctx.fillText(nowmoment.format(dateFormat), 0, radius * 0.5);
+            ctx.fillText(dateFormat(now, dateMask), 0, radius * 0.5)
           }
           catch (err) {
             showerror(err, ctx, radius)
@@ -445,8 +571,8 @@ class AnalogClock extends HTMLElement {
         globalThis.style_SecondHand = 3;
         if (config.style_secondhand) style_SecondHand = config.style_secondhand;
 
-        globalThis.dateFormat = "";
-        if (config.dateformat) dateFormat = config.dateformat;
+        globalThis.dateMask = "";
+        if (config.dateformat) dateMask = config.dateformat;
 
         globalThis.timeFormat = "";
         if (config.timeformat) timeFormat = config.timeformat;
@@ -502,7 +628,7 @@ class AnalogClock extends HTMLElement {
                 if (themes[i].style_hourhand) { style_HourHand = themes[i].style_hourhand };
                 if (themes[i].style_minutehand) { style_MinuteHand = themes[i].style_minutehand };
                 if (themes[i].style_secondhand) { style_SecondHand = themes[i].style_secondhand };
-                if (themes[i].dateformat) { dateFormat = themes[i].dateformat };
+                if (themes[i].dateformat) { dateMask = themes[i].dateFormat };
                 if (themes[i].timeformat) { timeFormat = themes[i].timeformat };
               }
             }
@@ -514,12 +640,9 @@ class AnalogClock extends HTMLElement {
     }
 
     function showerror(err, ctx, radius) {
-      console.error("ANALOG-CLOCK Error: " + err.message);
-      if (err.message = 'moment is not defined') {
-        console.info('Have you added moment.js as a resource in Lovelace.yaml?')
-        console.info('Also clear your browser cache, to make moment.js load.')
-        console.info('Find documentation here: https://github.com/tomasrudh/analogclock')
-      }
+      console.error("ANALOG-CLOCK Error: " + err.message)
+      const stackTraceArr = formatStackTrace(err.stack)
+      console.info(stackTraceArr[1])
       var img = new Image();
       img.src = 'https://cdn.jsdelivr.net/gh/tomasrudh/analogclock/Images/errorsign.png';
       img.onload = function (e) {


### PR DESCRIPTION
The by far biggest problem with AnalogClock has been moment.js. This release eliminates the need for moment.js.