### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An analog clock card for Home Assistant Lovelace. Colors are fully customizable,
 Some of the masks for 'dateformat' and 'timeformat' have changed text. Please see Formats for the new masks.
 ```
 
+[Formats](https://github.com/tomasrudh/analogclock/blob/3.0/Formats.md)
+
 ## Installation
 
 Install using HACS, search for 'Analog Clock'.
@@ -20,7 +22,7 @@ You might have to add a character and remove it again, before the Save button be
 
 ## Configuration
 
-For a list of available options for dateformat and timeformat, see Formats.
+For a list of available options for dateformat and timeformat, see [Formats](https://github.com/tomasrudh/analogclock/blob/3.0/Formats.md).
 
 ![Analog clock2](https://github.com/tomasrudh/analogclock/blob/main/Images/AnalogClock2.png?raw=true)
 


### PR DESCRIPTION
The by far biggest problem with AnalogClock has been moment.js. This release eliminates the need for moment.js.